### PR TITLE
Allow overriding API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ var Service = new AdWords.ManagedCustomerService({
   ADWORDS_REFRESH_TOKEN: 'your refresh token',
   ADWORDS_SECRET: 'your secret',
   ADWORDS_USER_AGENT: 'your user agent',
+  version: 'v201605',
 });
 ```
 

--- a/adWordsObject.js
+++ b/adWordsObject.js
@@ -17,7 +17,8 @@ function AdWordsObject(options) {
     ADWORDS_REFRESH_TOKEN: process.env.ADWORDS_REFRESH_TOKEN,
     ADWORDS_SECRET: process.env.ADWORDS_SECRET,
     ADWORDS_USER_AGENT: process.env.ADWORDS_USER_AGENT,
-    verbose: false
+    verbose: false,
+    version: 'v201605'
   });
 
   // check if all credentials are supplied
@@ -36,7 +37,7 @@ function AdWordsObject(options) {
   self.credentials = null;
   self.tokenUrl = 'https://www.googleapis.com/oauth2/v3/token';
   self.verbose = self.options.verbose;
-  self.version = 'v201509';
+  self.version = self.options.version;
 
   self.refresh = function(done) {
     // check if current credentials haven't expired

--- a/services/budgetService.js
+++ b/services/budgetService.js
@@ -58,7 +58,6 @@ function Service(options) {
     'BudgetStatus',
     'DeliveryMethod',
     'IsBudgetExplicitlyShared',
-    'Period'
   ];
 
   self.xmlns = 'https://adwords.google.com/api/adwords/cm/' + self.version;

--- a/services/campaignService.js
+++ b/services/campaignService.js
@@ -60,7 +60,6 @@ function Service(options) {
   };
 
   self.selectable = [
-    'ActiveViewCpmEnabled',
     'AdServingOptimizationStatus',
     'AdvertisingChannelSubType',
     'AdvertisingChannelType',
@@ -84,7 +83,6 @@ function Service(options) {
     'Labels',
     'Level',
     'Name',
-    'Period',
     'PricingMode',
     'RejectionReasons',
     'ServingStatus',


### PR DESCRIPTION
The API version v201509 is no longer supported.

This change updates to the latest version. Additionally it makes it easier to stay up-to-date without having to upgrade this library (assuming the API change is sufficiently backwards compatible).
