### PR TITLE
Reorder selector properties according to WSDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,11 @@ Getting your campaigns:
 
 ```javascript
 var selector = new AdWords.Selector.model({
-  dateRange: {min: '19700101', max: '20380101'},
   fields: service.selectable,
+  predicates: [],
+  dateRange: {min: '19700101', max: '20380101'},
   ordering: [{field: 'Name', sortOrder: 'ASCENDING'}],
-  paging: {startIndex: 0, numberResults: 100},
-  predicates: []
+  paging: {startIndex: 0, numberResults: 100}
 });
 
 service.get(clientCustomerId, selector, function(err, results) {
@@ -201,11 +201,11 @@ Getting your managed customers:
 
 ```javascript
 var selector = new AdWords.Selector.model({
-  dateRange: {min: '19700101', max: '20380101'},
   fields: service.selectable,
+  predicates: [],
+  dateRange: {min: '19700101', max: '20380101'},
   ordering: [{field: 'Name', sortOrder: 'ASCENDING'}],
-  paging: {startIndex: 0, numberResults: 100},
-  predicates: []
+  paging: {startIndex: 0, numberResults: 100}
 });
 
 service.get(clientCustomerId, selector, function(err, results) {


### PR DESCRIPTION
The CampaignService requires the selector properties to appear in a specific order.

If i run the example code, the API returns this error:

``` XML
<soap:Envelope 
  xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
  <soap:Body>
    <soap:Fault>
      <faultcode>soap:Client</faultcode>
      <faultstring>Unmarshalling Error: cvc-complex-type.2.4.a: Invalid content was found starting with element 'fields'. One of '{"https://adwords.google.com/api/adwords/cm/v201605":ordering, "https://adwords.google.com/api/adwords/cm/v201605":paging}' is expected. </faultstring>
    </soap:Fault>
  </soap:Body>
</soap:Envelope> 
```

This PR orders the selector properties according to the WSDL:
https://adwords.google.com/api/adwords/cm/v201605/CampaignService?wsdl
