### PR TITLE
Allow campaign to run for just one day

### DIFF
--- a/tests/unit/campaignService.spec.js
+++ b/tests/unit/campaignService.spec.js
@@ -111,6 +111,14 @@ describe('CampaignService', function() {
       expect(campaign.isValid()).toEqual(false);
       expect(campaign.validationError.length).toEqual(1);
     });
+
+    it('may start and end on the same date', function() {
+      var campaign = baseCampaign.clone();
+
+      campaign.set('endDate', campaign.get('startDate'));
+
+      expect(campaign.isValid()).toEqual(true);
+    });
   });
 
   describe('name', function() {

--- a/types/campaign.js
+++ b/types/campaign.js
@@ -36,19 +36,19 @@ var Campaign = Backbone.Model.extend({
 
     // combined date
     if (attrs.startDate && attrs.endDate) {
-      if (parseInt(attrs.startDate) >= parseInt(attrs.endDate)) {
+      if (parseInt(attrs.startDate) > parseInt(attrs.endDate)) {
         validationErrors.push(new Error('start date must be before end date'));
       }
     }
 
     if (attrs.startDate && !attrs.endDate) {
-      if (parseInt(attrs.startDate) >= parseInt(now.format('YYYYMMDD'))) {
+      if (parseInt(attrs.startDate) > parseInt(now.format('YYYYMMDD'))) {
         validationErrors.push(new Error('start date must be before end date'));
       }
     }
 
     if (!attrs.startDate && attrs.endDate) {
-      if (parseInt(now.format('YYYYMMDD')) >= parseInt(attrs.endDate)) {
+      if (parseInt(now.format('YYYYMMDD')) > parseInt(attrs.endDate)) {
         validationErrors.push(new Error('end date must be after start date'));
       }
     }


### PR DESCRIPTION
The Backbone validation callback requires that `endDate > startDate`. Google accepts `endDate == startDate`.
